### PR TITLE
Prevent errors when any selected module is unpublished

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -20,7 +20,10 @@ abstract class modspTabHelper {
 		
 		$items 						= array();
 		
-		for ($i=0;$i<count($mods);$i++) {
+		for ($i=0;$i<count($mods);$i++) 
+		{
+		    if (self::getModule($mods[$i]) !== null)
+		    {
 			if ( $ordering == 'ordering' )
 			{
 				$items[$i]['order'] = self::getModule($mods[$i])->ordering;
@@ -34,6 +37,7 @@ abstract class modspTabHelper {
 			{
 				$items[$i]['content'] 	= do_shortcode( $items[$i]['content'] );
 			}
+		    }
 		}
 
 		($ordering_direction=='ASC') ? asort ($items) : arsort ($items);//sorting


### PR DESCRIPTION
If a module is selected to be displayed in sp_tab and turned off then it throws noteces about trying to get property (ordering, params, moduleclass_sfx, title) of non-object 